### PR TITLE
Fix uptime drift and add user commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,7 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger",
+ "futures-util",
  "isahc",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ smol = "2.0.2"
 smolscale = "0.4.15"
 sqlx = {version="0.8.5", features=["sqlite", "runtime-async-std"]}
 teloxide = "0.15.0"
+futures-util = "0.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,10 +11,13 @@ use sqlx::{
     sqlite::{SqliteConnectOptions, SqlitePoolOptions, SqliteQueryResult},
 };
 use teloxide::{
-    Bot, RequestError,
-    prelude::Requester,
-    types::{ChatId, Message, Seconds},
+    prelude::*,
+    types::{
+        BotCommand, ChatId, InlineKeyboardButton, InlineKeyboardMarkup, MenuButton, Message, Seconds,
+    },
+    RequestError,
 };
+use futures_util::StreamExt;
 
 // ---------------------------- Configuration ----------------------------
 #[derive(Debug, Deserialize)]
@@ -51,7 +54,8 @@ static DB: Lazy<Pool<Sqlite>> = Lazy::new(|| {
               vm_id TEXT PRIMARY KEY,
               telegram_chat_id INTEGER,
               up_secs INTEGER DEFAULT 0,
-              paid_secs INTEGER DEFAULT 0
+              notified_secs INTEGER DEFAULT 0,
+              claimed_secs INTEGER DEFAULT 0
             )
             "#,
         )
@@ -70,12 +74,27 @@ fn main() {
     let bot = Bot::new(CONFIG.telegram_bot_token.clone());
 
     smolscale::block_on(async move {
+        let commands = vec![
+            BotCommand::new("register", "Register your VM. Usage: /register <id>"),
+            BotCommand::new("uptime", "Show your VM's total uptime"),
+            BotCommand::new("unclaimed", "View unclaimed Plus days"),
+            BotCommand::new("claim", "Claim accumulated Plus days"),
+            BotCommand::new("deregister", "Deregister your VM"),
+            BotCommand::new("menu", "Show command menu"),
+        ];
+        bot.set_my_commands(commands).await.unwrap();
+        bot
+            .set_chat_menu_button()
+            .menu_button(MenuButton::Commands)
+            .send()
+            .await
+            .unwrap();
         teloxide::repl(bot.clone(), handler)
             .race(async {
                 update_uptime_loop().await.unwrap();
             })
             .race(async {
-                send_plus_loop(bot).await.unwrap();
+                notify_uptime_loop(bot).await.unwrap();
             })
             .await;
     })
@@ -90,18 +109,77 @@ const GREETING: &str = "Hey there!\n\nTo register your testing VM to receive Plu
 
 const INVALID_VM: &str = "What you gave me is not a valid VM ID - please double check and make sure your text doesn't contain any other words or whitespace!\n\n您给我的不是有效的虚拟机 ID - 请再次检查并确保你的文本没有包含其他单词或空格！\n\nچیزی که به من دادید شناسه VM معتبر نیست - لطفاً دوباره بررسی کنید و مطمئن شوید که متن شما هیچ کلمه یا فاصله اضافی ندارد!\n\nТо, что вы мне дали, не является действительным идентификатором виртуальной машины - пожалуйста, перепроверьте и убедитесь, что в вашем тексте нет других слов или пробелов!";
 
-const GIFTCARD_PRELUDE: &str = "Thank you for keeping your testing VM up for 24 hours! Here is a 1-day Geph Plus giftcard 🎁 \n\n\n感谢您将测试虚拟机保持在线 24 小时！这是一张 1 天的迷雾通 Plus 礼品卡 🎁 \n\n\nممنون که ماشین مجازی تستی خود را به مدت 24 ساعت آنلاین نگه داشتید! این یک کارت هدیه 1 روزه Geph Plus است 🎁 \n\n\nСпасибо за то, что держали вашу тестовую виртуальную машину включенной 24 часа! Вот подарочная карта Geph Plus на 1 день 🎁";
+const THANKS_FOR_DAY: &str = "Thank you for keeping your testing VM online for 24 hours! You've earned another day of Geph Plus. Use /claim to redeem your days.";
+
+#[derive(Clone, Debug)]
+enum Command {
+    Register(String),
+    Uptime,
+    Unclaimed,
+    Claim,
+    Deregister,
+    Menu,
+}
+
+fn parse_command(text: &str) -> Option<Command> {
+    let mut parts = text.trim().split_whitespace();
+    let cmd = parts.next()?;
+    match cmd {
+        "/register" => parts.next().map(|id| Command::Register(id.to_owned())),
+        "/uptime" => Some(Command::Uptime),
+        "/unclaimed" => Some(Command::Unclaimed),
+        "/claim" => Some(Command::Claim),
+        "/deregister" => Some(Command::Deregister),
+        "/menu" => Some(Command::Menu),
+        _ => None,
+    }
+}
+
+fn menu_markup(registered: bool) -> InlineKeyboardMarkup {
+    if registered {
+        InlineKeyboardMarkup::new(vec![
+            vec![InlineKeyboardButton::switch_inline_query_current_chat(
+                "My VM's total uptime",
+                "/uptime",
+            )],
+            vec![InlineKeyboardButton::switch_inline_query_current_chat(
+                "View unclaimed Plus days",
+                "/unclaimed",
+            )],
+            vec![InlineKeyboardButton::switch_inline_query_current_chat(
+                "Claim Plus",
+                "/claim",
+            )],
+            vec![InlineKeyboardButton::switch_inline_query_current_chat(
+                "Deregister VM",
+                "/deregister",
+            )],
+        ])
+    } else {
+        InlineKeyboardMarkup::new(vec![vec![
+            InlineKeyboardButton::switch_inline_query_current_chat(
+                "Register VM",
+                "/register ",
+            ),
+        ]])
+    }
+}
+
+async fn send_menu(bot: &Bot, chat_id: ChatId, registered: bool) -> Result<(), RequestError> {
+    bot.send_message(chat_id, "Choose a command from the menu below:")
+        .reply_markup(menu_markup(registered))
+        .await?;
+    Ok(())
+}
 
 // ---------------------------- Telegram handler ----------------------------
 async fn handler(bot: Bot, msg: Message) -> Result<(), RequestError> {
-    let Some(text) = msg.text().map(|t| t.to_owned()) else {
-        return Ok(());
-    };
+    let Some(text) = msg.text() else { return Ok(()); };
     let chat_id = msg.chat.id;
 
     log::debug!("received message w/ text={text}");
 
-    let chat_has_registered_agent = sqlx::query_scalar::<_, bool>(
+    let registered = sqlx::query_scalar::<_, bool>(
         "SELECT EXISTS(SELECT 1 FROM agent_records WHERE telegram_chat_id = ?)",
     )
     .bind(chat_id.0)
@@ -109,22 +187,125 @@ async fn handler(bot: Bot, msg: Message) -> Result<(), RequestError> {
     .await
     .map_err(|_| RequestError::RetryAfter(Seconds::from_seconds(5)))?;
 
-    if chat_has_registered_agent {
-        bot.send_message(chat_id, THANKS_ALREADY_REGISTERED).await?;
-    } else if &text == "/start" {
-        bot.send_message(chat_id, GREETING).await?;
-    } else {
-        let result: SqliteQueryResult =
-            sqlx::query("UPDATE agent_records SET telegram_chat_id = $1 WHERE vm_id = $2")
+    if text == "/start" || text == "/menu" {
+        send_menu(&bot, chat_id, registered).await?;
+        return Ok(());
+    }
+
+    match parse_command(text) {
+        Some(Command::Register(vm_id)) => {
+            if registered {
+                bot.send_message(chat_id, THANKS_ALREADY_REGISTERED).await?;
+            } else {
+                let result: SqliteQueryResult = sqlx::query(
+                    "UPDATE agent_records SET telegram_chat_id = $1 WHERE vm_id = $2",
+                )
                 .bind(chat_id.0)
-                .bind(text)
+                .bind(vm_id)
                 .execute(&*DB)
                 .await
                 .unwrap();
-        if result.rows_affected() > 0 {
-            bot.send_message(chat_id, REGISTER_SUCCESS).await?;
-        } else {
-            bot.send_message(chat_id, INVALID_VM).await?;
+                if result.rows_affected() > 0 {
+                    bot.send_message(chat_id, REGISTER_SUCCESS).await?;
+                    send_menu(&bot, chat_id, true).await?;
+                } else {
+                    bot.send_message(chat_id, INVALID_VM).await?;
+                }
+            }
+        }
+        Some(Command::Uptime) => {
+            if registered {
+                let secs: i64 = sqlx::query_scalar(
+                    "SELECT up_secs FROM agent_records WHERE telegram_chat_id = ?",
+                )
+                .bind(chat_id.0)
+                .fetch_one(&*DB)
+                .await
+                .unwrap();
+                let hours = secs / 3600;
+                bot.send_message(chat_id, format!("Your VM has been up for {hours} hours.")).await?;
+            } else {
+                bot.send_message(chat_id, GREETING).await?;
+            }
+        }
+        Some(Command::Unclaimed) => {
+            if registered {
+                let days: i64 = sqlx::query_scalar(
+                    "SELECT (notified_secs - claimed_secs) / 86400 FROM agent_records WHERE telegram_chat_id = ?",
+                )
+                .bind(chat_id.0)
+                .fetch_one(&*DB)
+                .await
+                .unwrap();
+                bot.send_message(chat_id, format!("Unclaimed Plus days: {days}")).await?;
+            } else {
+                bot.send_message(chat_id, GREETING).await?;
+            }
+        }
+        Some(Command::Claim) => {
+            if registered {
+                let days: i64 = sqlx::query_scalar(
+                    "SELECT (notified_secs - claimed_secs) / 86400 FROM agent_records WHERE telegram_chat_id = ?",
+                )
+                .bind(chat_id.0)
+                .fetch_one(&*DB)
+                .await
+                .unwrap();
+                if days > 0 {
+                    let body = json!({
+                        "days_per_card": days,
+                        "num_cards": 1,
+                        "secret": CONFIG.giftcard_api_secret
+                    });
+                    let giftcard = isahc::Request::post(
+                        "https://web-backend.geph.io/support/create-giftcards",
+                    )
+                    .header(isahc::http::header::CONTENT_TYPE, "application/json")
+                    .body(body.to_string())
+                    .unwrap()
+                    .send()
+                    .unwrap()
+                    .text()
+                    .unwrap();
+                    bot.send_message(chat_id, giftcard).await?;
+                    sqlx::query(
+                        "UPDATE agent_records SET claimed_secs = claimed_secs + $1 WHERE telegram_chat_id = $2;",
+                    )
+                    .bind(days * 86400)
+                    .bind(chat_id.0)
+                    .execute(&*DB)
+                    .await
+                    .unwrap();
+                } else {
+                    bot.send_message(chat_id, "No unclaimed days yet.").await?;
+                }
+            } else {
+                bot.send_message(chat_id, GREETING).await?;
+            }
+        }
+        Some(Command::Deregister) => {
+            if registered {
+                sqlx::query(
+                    "UPDATE agent_records SET telegram_chat_id = NULL WHERE telegram_chat_id = ?",
+                )
+                .bind(chat_id.0)
+                .execute(&*DB)
+                .await
+                .unwrap();
+                bot.send_message(chat_id, "Your VM has been deregistered.").await?;
+            } else {
+                bot.send_message(chat_id, GREETING).await?;
+            }
+        }
+        Some(Command::Menu) => {
+            send_menu(&bot, chat_id, registered).await?;
+        }
+        None => {
+            if registered {
+                send_menu(&bot, chat_id, true).await?;
+            } else {
+                bot.send_message(chat_id, GREETING).await?;
+            }
         }
     }
     Ok(())
@@ -132,6 +313,7 @@ async fn handler(bot: Bot, msg: Message) -> Result<(), RequestError> {
 
 // ---------------------------- Background loops ----------------------------
 async fn update_uptime_loop() -> anyhow::Result<()> {
+    let mut ticker = smol::Timer::interval(Duration::from_secs(300));
     loop {
         let url = format!(
             "http://104.194.80.160:3000/available_vms?secret={}",
@@ -144,61 +326,54 @@ async fn update_uptime_loop() -> anyhow::Result<()> {
             log::debug!("updating up_secs for vm_id = {vm_id}");
             sqlx::query(
                 r#"
-INSERT INTO agent_records (vm_id, telegram_chat_id, up_secs, paid_secs)
-VALUES ($1, NULL, 60, 0)
+INSERT INTO agent_records (
+    vm_id,
+    telegram_chat_id,
+    up_secs,
+    notified_secs,
+    claimed_secs
+)
+VALUES ($1, NULL, 300, 0, 0)
 ON CONFLICT(vm_id) DO UPDATE SET
-    up_secs = agent_records.up_secs + 60;
+    up_secs = agent_records.up_secs + 300;
             "#,
             )
             .bind(vm_id)
             .execute(&*DB)
             .await?;
         }
-        smol::Timer::after(Duration::from_secs(60)).await;
+        ticker.next().await;
     }
 }
 
-async fn send_plus_loop(bot: Bot) -> anyhow::Result<()> {
+async fn notify_uptime_loop(bot: Bot) -> anyhow::Result<()> {
+    let mut ticker = smol::Timer::interval(Duration::from_secs(300));
     loop {
-        let to_pays: Vec<(String, i64, u32)> = sqlx::query_as(
+        let notifications: Vec<(i64, i64)> = sqlx::query_as(
             r#"
-SELECT vm_id, telegram_chat_id, (up_secs - paid_secs) / 86400 AS unpaid_days
+SELECT telegram_chat_id, (up_secs - notified_secs) / 86400 AS new_days
 FROM agent_records
 WHERE telegram_chat_id IS NOT NULL
-  AND (up_secs - paid_secs) > 86400
+  AND (up_secs - notified_secs) >= 86400
             "#,
         )
         .fetch_all(&*DB)
         .await?;
 
-        for (vm_id, tgram_chatid, unpaid_days) in to_pays {
-            let body = json!({
-                "days_per_card": unpaid_days,
-                "num_cards": 1,
-                "secret": CONFIG.giftcard_api_secret
-            });
-            let giftcard =
-                isahc::Request::post("https://web-backend.geph.io/support/create-giftcards")
-                    .header(isahc::http::header::CONTENT_TYPE, "application/json")
-                    .body(body.to_string())?
-                    .send()?
-                    .text()?;
-            log::debug!(
-                "sending {unpaid_days} days to vm_id={vm_id} & tgram_chatid={tgram_chatid}"
-            );
-
-            bot.send_message(ChatId(tgram_chatid), GIFTCARD_PRELUDE)
-                .await?;
-            bot.send_message(ChatId(tgram_chatid), giftcard).await?;
+        for (chat_id, new_days) in notifications {
+            for _ in 0..new_days {
+                bot.send_message(ChatId(chat_id), THANKS_FOR_DAY).await?;
+            }
 
             sqlx::query(
-                "UPDATE agent_records SET paid_secs = paid_secs + $1 WHERE telegram_chat_id = $2;",
+                "UPDATE agent_records SET notified_secs = notified_secs + $1 WHERE telegram_chat_id = $2;",
             )
-            .bind(unpaid_days * 86400)
-            .bind(tgram_chatid)
+            .bind(new_days * 86400)
+            .bind(chat_id)
             .execute(&*DB)
             .await?;
         }
-        smol::Timer::after(Duration::from_secs(300)).await;
+
+        ticker.next().await;
     }
 }


### PR DESCRIPTION
## Summary
- stop timer drift with `Timer::interval`
- send a message each day of uptime
- add bot command menu for claiming and checking Plus
- support deregistering a VM

## Testing
- `cargo check`