### PR TITLE
Fix uptime drift and add user commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,6 +1101,7 @@ dependencies = [
  "anyhow",
  "clap",
  "env_logger",
+ "futures-util",
  "isahc",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ smol = "2.0.2"
 smolscale = "0.4.15"
 sqlx = {version="0.8.5", features=["sqlite", "runtime-async-std"]}
 teloxide = "0.15.0"
+futures-util = "0.3"


### PR DESCRIPTION
## Summary
- stop timer drift with `Timer::interval`
- send a message each day of uptime
- add bot command menu for claiming and checking Plus
- support deregistering a VM
- add language selection and improved inline menu

## Testing
- `cargo check` *(fails: `cargo` not installed)*